### PR TITLE
Rename backup handler file

### DIFF
--- a/update-encryption.php
+++ b/update-encryption.php
@@ -186,7 +186,7 @@ if ($command == 'scan') {
     $backupHandler = null;
     if ($params['dump']) {
         $fileHandler   = fopen($params['dump'], 'a');
-        $backupHandler = fopen('backup-' . $params['dump'], 'a');
+        $backupHandler = fopen($params['dump'] . '.bckp', 'a');
     }
     foreach ($data as $row) {
         $value = $row[$field];


### PR DESCRIPTION
in case I need to place backup into `var/backup.sql` it tries to place it into `backup-var/backup.sql` and this is impossible for Cloud hosted projects