### PR TITLE
Do not break execution when decryptor returns empty string

### DIFF
--- a/update-encryption.php
+++ b/update-encryption.php
@@ -323,7 +323,7 @@ if ($command == 'scan') {
     while ( ($row = $data->fetch(PDO::FETCH_ASSOC)) !== false) {
         $value = $row[$field];
         $decrypted   = decrypt($value, $key);
-        if ($decrypted === null) {
+        if (empty($decrypted)) {
             message("ERROR - unable to decrypt value '$value', for the record with $idField=" . $row[$idField] . ". Skipping...");
             continue;
         }


### PR DESCRIPTION
If you have some corrupted encrypted values in your database (e.g. you have changed your encryption key before, didn't update the value, and removed the old key), decryptor returns an empty string. Since it doesn't equal `null`, it passes the validation, but later it breaks the whole script with exception.